### PR TITLE
implement new Temperature check using libsensors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get -y install libsystemd-dev
+        run: sudo apt-get -y install libsystemd-dev libsensors-dev
 
       - name: Cache cargo dependencies
         id: cache-cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libsensors-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1730cc7164b96de1d460c1f87c993430a3dda88ee336f0d2ea9a52097243132"
+
+[[package]]
 name = "libsystemd"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +730,7 @@ dependencies = [
  "mockall",
  "nix",
  "reqwest",
+ "sensors",
  "serde",
  "systemd-journal-logger",
  "text_placeholder",
@@ -1157,6 +1164,16 @@ checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "sensors"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3af4792f6a434642b5805ab1f086a621a369ad06a0d466ab89aeb556ddd6d0"
+dependencies = [
+ "libc",
+ "libsensors-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,13 @@ async-trait = "0.1"
 text_placeholder = "0.4"
 chrono = { version = "0.4", features = ["std", "clock"], default-features = false }
 lettre = { version = "0.10", features = ["smtp-transport", "tokio1-native-tls", "builder"], default-features = false }
+sensors = { version = "0.2", optional = true }
 
 [dev-dependencies]
 mockall = "0.11"
 
 [features]
+sensors = ["dep:sensors"]
 systemd = ["dep:libsystemd", "dep:systemd-journal-logger"]
 
 [profile.release]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM rust:alpine as builder
 
-RUN apk add --no-cache musl-dev openssl-dev
+RUN apk add --no-cache musl-dev openssl-dev lm-sensors-dev
 
 WORKDIR /app
 RUN cargo init
 COPY Cargo.toml Cargo.lock ./
-RUN cargo build --release
+RUN cargo build --release --features sensors
 RUN cargo clean -p minmon
 
 COPY ./src ./src
@@ -14,7 +14,7 @@ RUN cargo install --path .
 
 FROM alpine
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl lm-sensors-libs
 
 COPY --from=builder /usr/local/cargo/bin/minmon /usr/local/bin
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Implemented are these checks:
 - [Memory usage](./doc/check.md#memoryusage)
 - [Pressure average](./doc/check.md#pressureaverage)
 - [Process exit status](./doc/check.md#processexitstatus)
+- [Temperature](./doc/check.md#temperature)
 
 See Roadmap for [further ideas](#check-ideas).
 
@@ -204,6 +205,10 @@ You can enable and start the service with `systemctl daemon-reload && systemctl 
 - Logging to journal.
 - Notify systemd about start-up completion (`Type=notify`).
 - Periodically reset systemd watchdog (`WatchdogSec=x`).
+
+# lm_sensors integration (optional)
+Build with `--features sensors` to enable support for lm_sensors.\
+For the docker image, optionally mount your lm_sensors config file(s) to `/etc/sensors.d/`.
 
 # Roadmap
 ## Check ideas

--- a/deny.toml
+++ b/deny.toml
@@ -11,4 +11,4 @@ copyleft = "deny"
 allow-osi-fsf-free = "both"
 unused-allowed-license = "warn"
 confidence-threshold = 0.95
-allow = ["Unicode-DFS-2016", "0BSD"]
+allow = ["Unicode-DFS-2016", "0BSD", "MirOS"]

--- a/doc/check.md
+++ b/doc/check.md
@@ -106,6 +106,28 @@ Name of the file given by the path.
 ## Placeholders
 - `status_code`: Process exit status code.
 
+# Temperature
+Checks a temperature using lm_sensors.
+
+## Check options
+Wildcards are allowed in the sensor name as long as only one sensor is matched.\
+Specifying the feature is optional as long as there is only one temperature feature in the sensor.
+
+| name | example | optional | default |
+|:---|:---|:---:|:---|
+| sensors | `[sensor = "acpitz-*", feature = "temp1"]` | ❌ | |
+
+## Alarm options
+| name | example | optional | default |
+|:---|:---|:---:|:---|
+| temperature | `80` | ❌ | |
+
+## IDs
+Name of the sensor and feature as provided by lm_sensors (e.g. `acpitz-acpi-0/temp1).
+
+## Placeholders
+- `temperature`: Measured temperature (in °C).
+
 ---
 
 # Alarm

--- a/src/alarm/mod.rs
+++ b/src/alarm/mod.rs
@@ -5,10 +5,14 @@ use async_trait::async_trait;
 mod level;
 mod state_machine;
 mod status_code;
+#[cfg(feature = "sensors")]
+mod temperature;
 
 pub use level::Level;
 pub use state_machine::{StateHandler, StateMachine};
 pub use status_code::StatusCode;
+#[cfg(feature = "sensors")]
+pub use temperature::Temperature;
 
 #[cfg_attr(test, mockall::automock(type Item=u8;))]
 pub trait DataSink: Send + Sync + Sized {

--- a/src/alarm/temperature.rs
+++ b/src/alarm/temperature.rs
@@ -1,0 +1,44 @@
+use crate::{Error, PlaceholderMap, Result};
+
+use super::{DataSink, SinkDecision};
+use crate::config;
+
+pub struct Temperature {
+    temperature: i16,
+}
+
+impl TryFrom<&config::Alarm> for Temperature {
+    type Error = Error;
+
+    fn try_from(alarm: &config::Alarm) -> std::result::Result<Self, self::Error> {
+        if let config::AlarmType::Temperature(temperature) = &alarm.type_ {
+            if temperature.temperature < -273 {
+                Err(Error(String::from(
+                    "'temperature' cannot be less than -273°C.",
+                )))
+            } else {
+                Ok(Self {
+                    temperature: temperature.temperature,
+                })
+            }
+        } else {
+            Err(Error(String::from("Expected temperature alarm config.")))
+        }
+    }
+}
+
+impl DataSink for Temperature {
+    type Item = i16;
+
+    fn put_data(&mut self, data: &Self::Item) -> Result<SinkDecision> {
+        Ok(if *data > self.temperature {
+            SinkDecision::Bad
+        } else {
+            SinkDecision::Good
+        })
+    }
+
+    fn add_placeholders(data: &Self::Item, placeholders: &mut PlaceholderMap) {
+        placeholders.insert(String::from("temperature"), data.to_string());
+    }
+}

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -10,6 +10,8 @@ mod filesystem_usage;
 mod memory_usage;
 mod pressure_average;
 mod process_exit_status;
+#[cfg(feature = "sensors")]
+mod temperature;
 
 #[async_trait]
 pub trait Check: Send + Sync {
@@ -212,6 +214,10 @@ pub fn from_check_config(
             process_exit_status::ProcessExitStatus,
             alarm::StatusCode,
         >(check_config, actions),
+        #[cfg(feature = "sensors")]
+        config::CheckType::Temperature(_) => {
+            factory::<temperature::Temperature, alarm::Temperature>(check_config, actions)
+        }
     }
     .map_err(|x| {
         Error(format!(

--- a/src/check/temperature.rs
+++ b/src/check/temperature.rs
@@ -1,0 +1,125 @@
+use super::DataSource;
+use crate::config;
+use crate::{Error, Result};
+use async_trait::async_trait;
+
+type Item = i16;
+
+pub struct Temperature {
+    id: Vec<String>,
+    sensors: Vec<SensorsId>,
+}
+
+struct SensorsId {
+    pub sensor: String,
+    pub feature: String,
+}
+
+impl std::fmt::Display for SensorsId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.sensor, self.feature)
+    }
+}
+
+impl Temperature {
+    fn get_temperature(sensors_id: &SensorsId) -> Result<i16> {
+        let sensor = sensors::Sensors::new();
+        // these unwraps cannot happen here as they are checked in try_from
+        for chip in sensor.detected_chips(&sensors_id.sensor).unwrap() {
+            if let Some(feature) = chip
+                .into_iter()
+                .find(|x| x.get_label().unwrap() == sensors_id.feature)
+            {
+                if let Some(subfeature) = feature.into_iter().find(|x| {
+                    *x.subfeature_type() == sensors::SubfeatureType::SENSORS_SUBFEATURE_TEMP_INPUT
+                }) {
+                    return Ok(subfeature
+                        .get_value()
+                        .map_err(|x| Error(format!("Could not read temperature: {x}")))?
+                        as Item);
+                };
+            }
+        }
+        Err(Error(String::from("Could not read temperature.")))
+    }
+}
+
+impl TryFrom<&config::SensorsId> for SensorsId {
+    type Error = Error;
+
+    fn try_from(sensors_id: &config::SensorsId) -> std::result::Result<Self, Self::Error> {
+        let mut res = None;
+        let sensor = sensors::Sensors::new();
+        for chip in sensor.detected_chips(&sensors_id.sensor).map_err(|x| {
+            Error(format!(
+                "Failed to parse sensor name '{}': {x}",
+                sensors_id.sensor
+            ))
+        })? {
+            // these unwraps cannot happen when using the iterator
+            let chip_name = chip.get_name().unwrap();
+            for feature in chip
+                .into_iter()
+                .filter(|x| *x.feature_type() == sensors::FeatureType::SENSORS_FEATURE_TEMP)
+            {
+                let label = feature.get_label().unwrap();
+                if let Some(feature_label) = &sensors_id.feature {
+                    if *feature_label != label {
+                        continue;
+                    }
+                }
+                for _ in feature.into_iter().filter(|x| {
+                    *x.subfeature_type() == sensors::SubfeatureType::SENSORS_SUBFEATURE_TEMP_INPUT
+                }) {
+                    if res.is_some() {
+                        return Err(Error(format!("Sensor '{sensors_id}' is not unique.")));
+                    }
+                    res = Some(Self {
+                        sensor: chip_name.clone(),
+                        feature: label.clone(),
+                    });
+                }
+            }
+        }
+        res.ok_or(Error(format!("Sensor '{sensors_id}' not found.")))
+    }
+}
+
+impl TryFrom<&config::Check> for Temperature {
+    type Error = Error;
+
+    fn try_from(check: &config::Check) -> std::result::Result<Self, self::Error> {
+        if let config::CheckType::Temperature(temperature) = &check.type_ {
+            let sensors = temperature
+                .sensors
+                .iter()
+                .map(SensorsId::try_from)
+                .collect::<Result<Vec<SensorsId>>>()?;
+            let id = sensors.iter().map(|x| x.to_string()).collect();
+            Ok(Self { id, sensors })
+        } else {
+            panic!();
+        }
+    }
+}
+
+#[async_trait]
+impl DataSource for Temperature {
+    type Item = Item;
+
+    async fn get_data(&self) -> Result<Vec<Result<Self::Item>>> {
+        Ok(self
+            .sensors
+            .iter()
+            .map(Temperature::get_temperature)
+            .collect())
+    }
+
+    fn format_data(data: &Self::Item) -> String {
+        format!("temperature {data}°C")
+    }
+
+    fn ids(&self) -> &[String] {
+        &self.id[..]
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -207,6 +207,8 @@ pub enum CheckType {
     MemoryUsage(CheckMemoryUsage),
     PressureAverage(CheckPressureAverage),
     ProcessExitStatus(CheckProcessExitStatus),
+    #[cfg(feature = "sensors")]
+    Temperature(CheckTemperature),
 }
 
 #[derive(Deserialize, PartialEq, Debug)]
@@ -248,6 +250,28 @@ pub enum PressureChoice {
     Some,
     Full,
     Both,
+}
+
+#[cfg(feature = "sensors")]
+#[derive(Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct CheckTemperature {
+    pub sensors: Vec<SensorsId>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Clone)]
+pub struct SensorsId {
+    pub sensor: String,
+    pub feature: Option<String>,
+}
+
+impl std::fmt::Display for SensorsId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(feature) = &self.feature {
+            return write!(f, "{}/{feature}", self.sensor);
+        }
+        write!(f, "{}", self.sensor)
+    }
 }
 
 #[derive(Deserialize, PartialEq, Debug)]
@@ -309,6 +333,8 @@ pub enum AlarmType {
     Default(AlarmDefault),
     StatusCode(AlarmStatusCode),
     Level(AlarmLevel),
+    #[cfg(feature = "sensors")]
+    Temperature(AlarmTemperature),
 }
 
 // This is a dummy that is used if no alarm specific fields are found.
@@ -327,6 +353,13 @@ pub struct AlarmLevel {
 #[serde(deny_unknown_fields)]
 pub struct AlarmStatusCode {
     pub status_codes: Vec<u8>,
+}
+
+#[cfg(feature = "sensors")]
+#[derive(Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct AlarmTemperature {
+    pub temperature: i16,
 }
 
 mod default {


### PR DESCRIPTION
This implements temperature checks using lm_sensors. Using `/sys/class/thermal` without lm_sensors turned out to now really work well because the numbering of the thermal zones is not deterministic. By default this feature is disabled (due to the extra dependency). The docker image is built with this feature enabled.