### PR TITLE
Build ARMv7 and ARMv8 docker images

### DIFF
--- a/.github/workflows/docker-publish-cross.yml
+++ b/.github/workflows/docker-publish-cross.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/arm64/v8
+          platforms: linux/arm/v7,linux/arm64/v8
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v2
@@ -50,6 +50,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
+      # Workaround: https://github.com/docker/buildx/issues/395
+      - name: Run Docker on tmpfs
+        uses: JonasAlfredsson/docker-on-tmpfs@v1
+        with:
+          tmpfs_size: 5
+          swap_size: 4
+
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v3
@@ -57,7 +64,7 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64/v8
+          platforms: linux/arm/v7,linux/arm64/v8
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM rust:alpine as builder
+FROM rust:slim-bullseye as builder
 
-RUN apk add --no-cache musl-dev openssl-dev lm-sensors-dev
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libc-dev \
+    libssl-dev \
+    libsensors-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 RUN cargo init
@@ -12,9 +17,12 @@ COPY ./src ./src
 RUN cargo install --path .
 
 
-FROM alpine
+FROM debian:bullseye-slim
 
-RUN apk add --no-cache openssl lm-sensors-libs
+RUN apt-get update && apt-get install -y \
+    openssl \
+    libsensors5 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/cargo/bin/minmon /usr/local/bin
 


### PR DESCRIPTION
only for releases because it takes so long (~1 hour)