### PR TITLE
Init log level for systemd journal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ fn init_logging(config: &config::Config) -> Result<()> {
         #[cfg(feature = "systemd")]
         config::LogTarget::Journal => {
             systemd::init_journal()?;
+            log::set_max_level(log::LevelFilter::from(config.log.level));
         }
     }
     Ok(())


### PR DESCRIPTION
Thanks for making this cool and simple monitoring tool!

I noticed the systemd journal is empty using the `Journal` log target. Looks like the default is [log::LevelFilter::Off](https://docs.rs/systemd-journal-logger/latest/systemd_journal_logger/fn.init.html) and it needs to be initialized explicitly.

```bash
# Before
$ journalctl --unit minmon.service
Apr 22 21:57:16 box systemd[1]: Starting MinMon monitoring and alarming daemon...
Apr 22 21:57:16 box systemd[1]: Started MinMon monitoring and alarming daemon.
Apr 22 22:01:02 box systemd[1]: Stopping MinMon monitoring and alarming daemon...
Apr 22 22:01:02 box systemd[1]: minmon.service: Deactivated successfully.
Apr 22 22:01:02 box systemd[1]: Stopped MinMon monitoring and alarming daemon.
```

```bash
# After
$ journalctl --unit minmon.service
Apr 22 22:01:02 box systemd[1]: Starting MinMon monitoring and alarming daemon...
Apr 22 22:01:02 box minmon[175119]: Starting MinMon v0.5.3..
Apr 22 22:01:02 box minmon[175119]: Systemd watchdog will be reset every 150000 milliseconds.
Apr 22 22:01:02 box minmon[175119]: Initializing 3 actions(s)..
Apr 22 22:01:02 box minmon[175119]: Action 'hc-success' initialized.
Apr 22 22:01:02 box minmon[175119]: Action 'hc-fail' initialized.
Apr 22 22:01:02 box minmon[175119]: Action 'hc-ping-event' initialized.
Apr 22 22:01:02 box minmon[175119]: Initializing report..
...
```


