### PR TITLE
allow the use of env vars in placeholders

### DIFF
--- a/doc/general.md
+++ b/doc/general.md
@@ -6,6 +6,7 @@ This configures the general behaviour of MinMon.
 |:---|:---|:---:|:---|
 | boot_delay | `60` | ✔ | |
 | start_delay | `10` | ✔ | |
+| env_var_prefix | `FOO_` | ✔ | `MINMON_` |
 
 ### boot_delay
 The minimum system uptime (in seconds) MinMon awaits when it starts before the checks begin.
@@ -13,3 +14,7 @@ Use this to give the monitored services some time to start after the system boot
 
 ### start_delay
 MinMon waits this many seconds when it starts before the checks begin.
+
+### env_var_prefix
+Prefix of environment variables that should be available as placeholders in the form of
+`{{env:MINMON_HELLO}}`.

--- a/doc/placeholders.md
+++ b/doc/placeholders.md
@@ -13,3 +13,7 @@ MinMon's uptime in seconds.
 ## minmon_uptime_iso
 MinMon's uptime as ISO8601 duration.
 This does not use the month and year fields because they are ambiguous.
+
+## env:MINMON_HELLO
+Value of the environment variable `MINMON_HELLO`.
+Only variables that match the prefix configured in the general config section are evaluated.

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,13 +17,22 @@ pub struct Config {
     pub checks: Vec<Check>,
 }
 
-#[derive(Default, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct General {
-    #[serde(default)]
     pub boot_delay: Option<u32>,
-    #[serde(default)]
     pub start_delay: Option<u32>,
+    pub env_var_prefix: String,
+}
+
+impl Default for General {
+    fn default() -> Self {
+        Self {
+            boot_delay: None,
+            start_delay: None,
+            env_var_prefix: default::env_var_prefix(),
+        }
+    }
 }
 
 #[derive(Default, Deserialize)]
@@ -580,6 +589,11 @@ pub struct AlarmTemperature {
 }
 
 pub mod default {
+    pub const ENV_VAR_PREFIX: &str = "MINMON_";
+    pub fn env_var_prefix() -> String {
+        ENV_VAR_PREFIX.into()
+    }
+
     pub const REPORT_INTERVAL: u32 = 604800;
     pub fn report_interval() -> u32 {
         REPORT_INTERVAL

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,24 @@ impl std::fmt::Display for Error {
     }
 }
 
+static mut ENV_VARS: Option<std::collections::HashMap<String, String>> = None;
+
+static INIT_ENV_VARS: std::sync::Once = std::sync::Once::new();
+
+pub fn init_env_vars(config: &config::Config) {
+    INIT_ENV_VARS.call_once(|| unsafe {
+        let mut env_vars = PlaceholderMap::new();
+        for (name, value) in std::env::vars() {
+            if name.starts_with(&config.general.env_var_prefix) {
+                env_vars.insert(format!("env:{name}"), value);
+            }
+        }
+        ENV_VARS = Some(env_vars);
+    });
+}
+
 fn global_placeholders() -> PlaceholderMap {
-    let mut res = PlaceholderMap::new();
+    let mut res = unsafe { ENV_VARS.as_ref() }.unwrap().clone();
     let system_uptime = uptime::system();
     let minmon_uptime = uptime::process();
     res.insert(

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,8 @@ async fn main_wrapper() -> Result<()> {
         systemd::init().await;
     }
 
+    minmon::init_env_vars(&config);
+
     let (report, checks) = minmon::from_config(&config)?;
 
     if let Some(start_delay) = minmon::start_delay(&config) {


### PR DESCRIPTION
using placeholder syntax `{{env:MINMON_HELLO}}` with a configurable prefix (default: `MINMON_`)